### PR TITLE
Temporarily store requests in Redis.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,11 +7,19 @@ var router = express.Router();
 var WebhookValidator = require('./models/webhook_validator');
 var SlackBot = require('./client/slackbot.js');
 
+var redis = require("redis"),
+    client = redis.createClient(process.env.REDIS_URL);
+
 app.use(bodyParser.json());
 
 router.use((req, res, next) => {
   // log each request to the console
   console.log('Request : ' +  req.method, req.url);
+  next();
+});
+
+router.use((req, res, next) => {
+  client.set(Date.now(), JSON.stringify(req.body));
   next();
 });
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "body-parser": "^1.15.1",
     "dotenv": "^2.0.0",
     "express": "^4.13.4",
+    "redis": "^2.6.2",
     "slack": "^7.2.0",
     "underscore": "^1.8.3"
   },


### PR DESCRIPTION
This will allow us to have a better visibility on what's going on, and to re-run the requests locally.
