### PR TITLE
Only log requests in Redis when necessary.

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,9 @@ router.use((req, res, next) => {
 });
 
 router.use((req, res, next) => {
-  client.set(Date.now(), JSON.stringify(req.body));
+  if (process.env.LOG_IN_REDIS) {
+    client.set(Date.now(), JSON.stringify(req.body));
+  }
   next();
 });
 


### PR DESCRIPTION
This will prevent Redis filling up when nothing is wrong.
Should we empty the Redis as well?
